### PR TITLE
Improve AttachLine Gizmos and Grab Point setup tool

### DIFF
--- a/ModProj/Assets/Toolkit/Scripts/AttachLine.cs
+++ b/ModProj/Assets/Toolkit/Scripts/AttachLine.cs
@@ -2,6 +2,11 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine.Rendering;
+#endif
+
 
 namespace CrossLink
 {
@@ -68,16 +73,35 @@ namespace CrossLink
 #if UNITY_EDITOR
         private void OnDrawGizmosSelected()
         {
-            Gizmos.color = Color.blue;
-            Gizmos.DrawLine(transform.forward * (lineStartPoint) + transform.position,
-                transform.forward * (lineEndPoint) + transform.position);
+            Vector3 start = transform.forward * lineStartPoint + transform.position;
+            Vector3 end = transform.forward * lineEndPoint + transform.position;
+
+            Color oldColor = Handles.color;
+            CompareFunction oldZTest = Handles.zTest;
+
+            Handles.zTest = CompareFunction.Always;
+
+            Handles.color = new Color(0f, 0f, 0f, 0.9f);
+            Handles.DrawAAPolyLine(6f, start, end);
+
+            Handles.color = Color.yellow;
+            Handles.DrawAAPolyLine(3f, start, end);
 
             if (lineOffset > 0)
             {
                 //Gizmos.DrawSphere(transform.position + transform.forward * designCallingPos, 0.05f);
 
-                Gizmos.DrawSphere(transform.position, lineOffset);
+                Handles.color = new Color(1f, 0.9f, 0f, 0.25f);
+                Handles.SphereHandleCap(
+                    0,
+                    transform.position,
+                    Quaternion.identity,
+                    lineOffset * 2f,
+                    EventType.Repaint);
             }
+
+            Handles.color = oldColor;
+            Handles.zTest = oldZTest;
         }
 #endif
     }

--- a/ModProj/Assets/Toolkit/Scripts/RagdollCharacter/RagdollReactAnimation.cs
+++ b/ModProj/Assets/Toolkit/Scripts/RagdollCharacter/RagdollReactAnimation.cs
@@ -82,7 +82,7 @@ namespace CrossLink
                 ib.grabDistanceLimit = true;
 
                 GameObject attachGO = null;
-                if (ib.attachList != null)
+                if (ib.attachList != null && ib.attachList.Length > 0 && ib.attachList[0] != null)
                 {
                     attachGO = ib.attachList[0].gameObject;
                 }
@@ -91,14 +91,26 @@ namespace CrossLink
                     attachGO = Instantiate(prefab, bone);
                 }
                 
-                attachGO.transform.localPosition = Vector3.zero;
-                if (TryGetBoneConnectionDirection(animator, bones[i], bone, out Vector3 attachLineDirection))
+                AttachLine attachLine = attachGO.GetComponent<AttachLine>();
+                if (attachLine == null)
                 {
+                    Debug.LogError("AttachLinesToAnimatorBones failed: AttachLine component not found on prefab instance.", attachGO);
+                    continue;
+                }
+
+                if (IsLimbBone(bones[i]) && TryGetBoneConnection(animator, bones[i], bone, out Transform targetBone, out Vector3 attachLineDirection, out float boneDistance))
+                {
+                    ConfigureLimbAttachLine(attachLine, bone, targetBone, attachLineDirection, boneDistance);
+                }
+                else if (TryGetBoneConnectionDirection(animator, bones[i], bone, out attachLineDirection))
+                {
+                    attachGO.transform.localPosition = Vector3.zero;
                     attachGO.transform.rotation = Quaternion.LookRotation(attachLineDirection, bone.up);
                 }
                 else
                 {
                     Debug.LogWarning("AttachLinesToAnimatorBones could not determine bone direction for: " + bones[i], bone);
+                    attachGO.transform.localPosition = Vector3.zero;
                     attachGO.transform.localRotation = Quaternion.identity;
                 }
                 attachGO.transform.localScale = Vector3.one;
@@ -135,6 +147,60 @@ namespace CrossLink
             { HumanBodyBones.LeftUpperLeg, HumanBodyBones.LeftLowerLeg },
             { HumanBodyBones.LeftLowerLeg, HumanBodyBones.LeftFoot },
         };
+
+        private static bool IsLimbBone(HumanBodyBones bone)
+        {
+            return bone == HumanBodyBones.RightUpperArm
+                || bone == HumanBodyBones.RightLowerArm
+                || bone == HumanBodyBones.LeftUpperArm
+                || bone == HumanBodyBones.LeftLowerArm
+                || bone == HumanBodyBones.RightUpperLeg
+                || bone == HumanBodyBones.RightLowerLeg
+                || bone == HumanBodyBones.LeftUpperLeg
+                || bone == HumanBodyBones.LeftLowerLeg;
+        }
+
+        private static void ConfigureLimbAttachLine(AttachLine attachLine, Transform sourceBone, Transform targetBone, Vector3 direction, float distance)
+        {
+            Transform attachTransform = attachLine.transform;
+            attachTransform.SetParent(sourceBone, true);
+            attachTransform.position = Vector3.Lerp(sourceBone.position, targetBone.position, 0.5f);
+            attachTransform.rotation = Quaternion.LookRotation(direction, sourceBone.up);
+
+            attachLine.lineStartPoint = distance * 0.4f;
+            attachLine.lineEndPoint = -distance * 0.4f;
+        }
+
+        private static bool TryGetBoneConnection(Animator animator, HumanBodyBones sourceBone, Transform sourceTransform,
+            out Transform targetTransform, out Vector3 direction, out float distance)
+        {
+            targetTransform = null;
+            direction = Vector3.forward;
+            distance = 0f;
+
+            if (!AttachLineLookAtBones.TryGetValue(sourceBone, out HumanBodyBones targetBone))
+            {
+                return false;
+            }
+
+            targetTransform = animator.GetBoneTransform(targetBone);
+            if (targetTransform == null)
+            {
+                return false;
+            }
+
+            direction = targetTransform.position - sourceTransform.position;
+            distance = direction.magnitude;
+            if (distance < 0.000001f)
+            {
+                direction = Vector3.forward;
+                distance = 0f;
+                return false;
+            }
+
+            direction /= distance;
+            return true;
+        }
 
         private static bool TryGetBoneConnectionDirection(Animator animator, HumanBodyBones sourceBone, Transform sourceTransform, out Vector3 direction)
         {


### PR DESCRIPTION
Make AttachLine Gizmos easier to see
Improve how the grab point tool places AttachLines for arm and leg bones

Before:
<img width="839" height="649" alt="image" src="https://github.com/user-attachments/assets/2314ee4c-6f08-479d-9ab1-79dd9fc6d393" />

After:
<img width="937" height="634" alt="image" src="https://github.com/user-attachments/assets/ce622320-42a1-48d4-a202-60ba35f95c96" />
