### PR TITLE
Draw cylinder instead of sphere for AttachLine.lineOffset

### DIFF
--- a/ModProj/Assets/Toolkit/Scripts/AttachLine.cs
+++ b/ModProj/Assets/Toolkit/Scripts/AttachLine.cs
@@ -89,19 +89,42 @@ namespace CrossLink
 
             if (lineOffset > 0)
             {
-                //Gizmos.DrawSphere(transform.position + transform.forward * designCallingPos, 0.05f);
-
-                Handles.color = new Color(1f, 0.9f, 0f, 0.25f);
-                Handles.SphereHandleCap(
-                    0,
-                    transform.position,
-                    Quaternion.identity,
-                    lineOffset * 2f,
-                    EventType.Repaint);
+                DrawLineOffsetCylinder(start, end, lineOffset);
             }
 
             Handles.color = oldColor;
             Handles.zTest = oldZTest;
+        }
+
+        private void DrawLineOffsetCylinder(Vector3 start, Vector3 end, float radius)
+        {
+            Vector3 axis = end - start;
+            if (axis.sqrMagnitude < 0.000001f)
+                return;
+
+            Vector3 normal = axis.normalized;
+            Vector3 right = transform.right * radius;
+            Vector3 up = transform.up * radius;
+
+            Handles.color = new Color(1f, 0.9f, 0f, 0.16f);
+            Handles.DrawSolidDisc(start, normal, radius);
+            Handles.DrawSolidDisc(end, normal, radius);
+
+            Handles.color = new Color(0f, 0f, 0f, 0.65f);
+            Handles.DrawWireDisc(start, normal, radius);
+            Handles.DrawWireDisc(end, normal, radius);
+            Handles.DrawAAPolyLine(3f, start + right, end + right);
+            Handles.DrawAAPolyLine(3f, start - right, end - right);
+            Handles.DrawAAPolyLine(3f, start + up, end + up);
+            Handles.DrawAAPolyLine(3f, start - up, end - up);
+
+            Handles.color = new Color(1f, 0.9f, 0f, 0.85f);
+            Handles.DrawWireDisc(start, normal, radius);
+            Handles.DrawWireDisc(end, normal, radius);
+            Handles.DrawAAPolyLine(1.5f, start + right, end + right);
+            Handles.DrawAAPolyLine(1.5f, start - right, end - right);
+            Handles.DrawAAPolyLine(1.5f, start + up, end + up);
+            Handles.DrawAAPolyLine(1.5f, start - up, end - up);
         }
 #endif
     }


### PR DESCRIPTION
lineOffset controls thickness of AttachLine, draw cylinder for gizmos instead.
<img width="864" height="654" alt="image" src="https://github.com/user-attachments/assets/a740b59e-99eb-4563-b644-8747cf9180db" />
